### PR TITLE
Increase the hscaling factor from 5b to 6b

### DIFF
--- a/hw/rtl/digital_macro/digital_macro.sv
+++ b/hw/rtl/digital_macro/digital_macro.sv
@@ -699,7 +699,7 @@ module digital_macro #(
         .en_i         (en_perf_counter_i                                                        ),
         .load_i       (1'b0                                                                     ),
         .d_i          ({(CC_COUNTER_BITWIDTH){1'b0}}                                            ),
-        .recount_en_i (flush_i | cmpt_en_fm                                                     ),
+        .recount_en_i (flush_i | cmpt_en_fm | (infinite_icon_loop_en_i & flip_raddr_o == 'd0 & fm_upstream_handshake)),
         .step_en_i    (~cmpt_idle_o                                                             ),
         .q_o          (cycle_per_cmpt_o                                                         ),
         .maxed_o      (                                                                         ),
@@ -730,9 +730,9 @@ module digital_macro #(
         .rst_ni       (rst_ni                                                                   ),
         .en_i         (en_perf_counter_i                                                        ),
         .load_i       (config_valid_fm_posedge                                                  ),
-        .d_i          (cmpt_max_num_i                                                           ),
+        .d_i          (cmpt_max_num_i                                                           ), // counter stop when reaching cmpt_max_num_i
         .recount_en_i (flush_i | cmpt_en_pos_trigger                                            ),
-        .step_en_i    (((~multi_cmpt_mode_idle_o) | infinite_icon_loop_en_i) & cmpt_idle_posedge),
+        .step_en_i    (((~multi_cmpt_mode_idle_o) & cmpt_idle_posedge) | (infinite_icon_loop_en_i & flip_raddr_o == 'd0 & fm_upstream_handshake)),
         .q_o          (cmpt_idx_o                                                               ),
         .maxed_o      (multi_cmpt_idx_maxed                                                     ),
         .overflow_o   (                                                                         )

--- a/hw/rtl/include/lagd_define.svh
+++ b/hw/rtl/include/lagd_define.svh
@@ -57,7 +57,7 @@
     `define NUM_SPIN 256
     `define BIT_J 4
     `define BIT_H 4
-    `define SCALING_BIT 5
+    `define SCALING_BIT 6
     `define PARALLELISM 4
     `define ENERGY_TOTAL_BIT 32
     `define FLIP_ICON_DEPTH `L1_FLIP_MEM_SIZE_B*8/(`NUM_SPIN)

--- a/hw/rtl/ising_core_wrap/ising_core_wrap.sv
+++ b/hw/rtl/ising_core_wrap/ising_core_wrap.sv
@@ -327,8 +327,8 @@ module ising_core_wrap import axi_pkg::*; import memory_island_pkg::*; import is
     // hw2reg
     assign hw2reg.output_status.dt_cfg_idle                  .de = en_aw;
     assign hw2reg.output_status.cmpt_idle                    .de = en_fm;
-    assign hw2reg.output_status.energy_fifo_update           .de = en_fm & ctnus_fifo_read;
-    assign hw2reg.output_status.spin_fifo_update             .de = en_fm & ctnus_fifo_read;
+    assign hw2reg.output_status.energy_fifo_update           .de = en_fm & (ctnus_fifo_read | ctnus_dgt_debug);
+    assign hw2reg.output_status.spin_fifo_update             .de = en_fm & (ctnus_fifo_read | ctnus_dgt_debug);
     assign hw2reg.output_status.debug_j_read_data_valid      .de = en_aw;
     assign hw2reg.output_status.debug_analog_dt_w_idle       .de = en_aw;
     assign hw2reg.output_status.debug_analog_dt_r_idle       .de = en_aw;

--- a/hw/rtl/ising_core_wrap/ising_core_wrap.sv
+++ b/hw/rtl/ising_core_wrap/ising_core_wrap.sv
@@ -277,6 +277,7 @@ module ising_core_wrap import axi_pkg::*; import memory_island_pkg::*; import is
     assign multi_cmpt_mode_en               = reg2hw.global_cfg_2.multi_cmpt_mode_en.q;
     assign config_spin_initial_skip[0]      = reg2hw.global_cfg_2.config_spin_initial_skip_0.q;
     assign config_spin_initial_skip[1]      = reg2hw.global_cfg_2.config_spin_initial_skip_1.q;
+    assign dgt_hscaling                     = reg2hw.global_cfg_2.dgt_hscaling.q;
 
     assign cmpt_max_num                     = reg2hw.cmpt_max_num.q;
 
@@ -288,7 +289,6 @@ module ising_core_wrap import axi_pkg::*; import memory_island_pkg::*; import is
     assign debug_cycle_per_spin_read        = reg2hw.counter_cfg_3.debug_cycle_per_spin_read.q;
     assign debug_spin_read_num              = reg2hw.counter_cfg_4.debug_spin_read_num.q;
     assign icon_last_raddr_plus_one         = reg2hw.counter_cfg_4.icon_last_raddr_plus_one.q;
-    assign dgt_hscaling                     = reg2hw.counter_cfg_4.dgt_hscaling.q;
 
     assign dgt_hbias = h_rdata;
 

--- a/hw/rtl/ising_core_wrap/ising_core_wrap.sv
+++ b/hw/rtl/ising_core_wrap/ising_core_wrap.sv
@@ -327,8 +327,8 @@ module ising_core_wrap import axi_pkg::*; import memory_island_pkg::*; import is
     // hw2reg
     assign hw2reg.output_status.dt_cfg_idle                  .de = en_aw;
     assign hw2reg.output_status.cmpt_idle                    .de = en_fm;
-    assign hw2reg.output_status.energy_fifo_update           .de = (ctnus_dgt_debug & energy_fifo_update) | ctnus_fifo_read;
-    assign hw2reg.output_status.spin_fifo_update             .de = (ctnus_dgt_debug & spin_fifo_update  ) | ctnus_fifo_read;
+    assign hw2reg.output_status.energy_fifo_update           .de = en_fm & ctnus_fifo_read;
+    assign hw2reg.output_status.spin_fifo_update             .de = en_fm & ctnus_fifo_read;
     assign hw2reg.output_status.debug_j_read_data_valid      .de = en_aw;
     assign hw2reg.output_status.debug_analog_dt_w_idle       .de = en_aw;
     assign hw2reg.output_status.debug_analog_dt_r_idle       .de = en_aw;

--- a/hw/rtl/lagd_core_reg/lagd_core_regs.hjson
+++ b/hw/rtl/lagd_core_reg/lagd_core_regs.hjson
@@ -64,6 +64,7 @@
         { bits: "17",    resval: "0",  name: "multi_cmpt_mode_en",          desc: "Whether to repeat the computation multiple times with the same configuration  (for power measurement purpose)"}
         { bits: "18",    resval: "0",  name: "config_spin_initial_skip_0",  desc: "Whether to skip current spin initial value, set 0"      }
         { bits: "19",    resval: "0",  name: "config_spin_initial_skip_1",  desc: "Whether to skip current spin initial value, set 1"      }
+        { bits: "25:20", resval: "1",  name: "dgt_hscaling",                desc: "Scaling factor for dgt"                                 }
       ]
     }
 
@@ -139,7 +140,6 @@
       fields: [
         { bits: "15:0",  resval: "1023", name: "debug_spin_read_num",       desc: "Cycle per debug spin read number"                       }
         { bits: "26:16", resval: "1024", name: "icon_last_raddr_plus_one",  desc: "Flip icon last address plus one"                        }
-        { bits: "31:27", resval: "4",    name: "dgt_hscaling",              desc: "Scaling factor for dgt"                                 }
       ]
     }
 

--- a/hw/unit_tests/digital_macro/config_pkg.sv
+++ b/hw/unit_tests/digital_macro/config_pkg.sv
@@ -14,7 +14,7 @@ package config_pkg;
     // design-time parameters
     parameter int NUM_SPIN = 256;
     parameter int BITDATA = 4;
-    parameter int SCALING_BIT = 5;
+    parameter int SCALING_BIT = 6;
     parameter int LITTLE_ENDIAN = `False; // True: little endian, False: big endian
     parameter int PIPESINTF = 1;
     parameter int PIPESMID = 1;

--- a/hw/unit_tests/energy_monitor/tb_energy_monitor.sv
+++ b/hw/unit_tests/energy_monitor/tb_energy_monitor.sv
@@ -57,7 +57,7 @@ module tb_energy_monitor;
     localparam int BITJ = 4; // J precision, min: 2 (including sign bit)
     localparam int BITH = 4; // bias precision, min: 2 (including sign bit)
     localparam int NUM_SPIN = 256; // number of spins
-    localparam int SCALING_BIT = 5; // bit width of scaling factor
+    localparam int SCALING_BIT = 6; // bit width of scaling factor
     localparam int PARALLELISM = 4; // number of parallel energy calculation units, min: 1
     localparam int LOCAL_ENERGY_BIT = $clog2(NUM_SPIN) + BITH + SCALING_BIT - 1 + 1; // bit width of local energy
     localparam int ENERGY_TOTAL_BIT = 32; // bit width of total energy

--- a/hw/unit_tests/ising_core_wrap/README.md
+++ b/hw/unit_tests/ising_core_wrap/README.md
@@ -1,0 +1,11 @@
+# Digital Macro Testbench
+
+This folder is for function verification of the ising_core_wrap module.
+
+To run the testbench, enter the command:
+
+```
+./ci/ut-run.sh --test=ising_core_wrap --defines="DATA_FROM_FILE=1"
+```
+
+There is no automatic checkers or scoreboards in the testbench. The final energy and spin results are manually checked to be the same as the one from the digital macro testbench.

--- a/hw/unit_tests/ising_core_wrap/README.md
+++ b/hw/unit_tests/ising_core_wrap/README.md
@@ -1,4 +1,4 @@
-# Digital Macro Testbench
+# Ising Core Wrap Testbench
 
 This folder is for function verification of the ising_core_wrap module.
 

--- a/hw/unit_tests/ising_core_wrap/hdl_file_list.tcl
+++ b/hw/unit_tests/ising_core_wrap/hdl_file_list.tcl
@@ -11,7 +11,8 @@ set HDL_FILES [ list \
     "./tb_ising_core_wrap.sv" \
     "${HDL_PATH}/lagd_mem_cfg_pkg.sv" \
     "${HDL_PATH}/lagd_pkg.sv" \
-    "${PROJECT_ROOT}/target/syn/tech/tsmc7ff/IPs/galena/galena.v" \
+    "${PROJECT_ROOT}/hw/tb/models/galena/galena_pkg.sv" \
+    "${PROJECT_ROOT}/hw/tb/models/galena/galena.sv" \
     "${HDL_PATH}/ising_core_wrap/ising_core_wrap.sv" \
     "${HDL_PATH}/memory_island/axi_to_mem_adapter.sv" \
     "${HDL_PATH}/memory_island/mem_multicut.sv" \

--- a/hw/unit_tests/ising_core_wrap/tb_ising_core_wrap.sv
+++ b/hw/unit_tests/ising_core_wrap/tb_ising_core_wrap.sv
@@ -795,7 +795,7 @@ task automatic print_results_read();
     $display("--------- Print Results By Register Read ---------");
     forever begin
         @ (posedge clk_i);
-        $display("[Time: %t] reg_txt_rsp.rdata: 'h%h", $time, reg_ext_rsp.rdata);
+        $display("[Time: %t] reg_ext_rsp.rdata: 'h%h", $time, reg_ext_rsp.rdata);
     end
 endtask
 

--- a/hw/unit_tests/ising_core_wrap/tb_ising_core_wrap.sv
+++ b/hw/unit_tests/ising_core_wrap/tb_ising_core_wrap.sv
@@ -82,6 +82,16 @@ module tb_ising_core_wrap;
     logic [`LAGD_AXI_DATA_WIDTH-1:0] axi_write_data;
     logic [1024-1:0] [`NUM_SPIN-1:0] flip_icon;
 
+    logic [`NUM_SPIN-1:0] config_spin_initial_0, config_spin_initial_1;
+    logic [`COUNTER_BITWIDTH-1:0] cycle_per_spin_write, cycle_per_wwl_low, cycle_per_wwl_high, cfg_trans_num;
+    logic [`SCALING_BIT-1:0] dgt_hscaling;
+    logic [$clog2(`FLIP_ICON_DEPTH):0] icon_last_raddr_plus_one;
+    logic [`COUNTER_BITWIDTH-1:0] debug_spin_read_num, debug_cycle_per_spin_read, cycle_per_spin_compute;
+    logic [`NUM_SPIN-1:0] wwl_vdd_cfg, wwl_vread_cfg, spin_wwl_strobe, spin_feedback, debug_j_one_hot_wwl;
+
+    integer i;
+    logic [`LAGD_REG_DATA_WIDTH-1:0] reg_data;
+
     // External AXI interconnect
     lagd_axi_slv_req_t axi_ext_slv_req_0 = 'd0;
     lagd_axi_slv_rsp_t axi_ext_slv_rsp_0;
@@ -111,7 +121,7 @@ module tb_ising_core_wrap;
                             debug_dt_configure_enable, en_comparison, en_analog_loop,
                             en_ef, en_ff, en_fm, en_em, en_aw, flush_en};
 
-    assign global_cfg_reg_2 = {12'd0, config_spin_initial_skip_1, config_spin_initial_skip_0, multi_cmpt_mode_en, infinite_icon_loop_en, ctnus_dgt_debug, ctnus_fifo_read, dgt_addr_upper_bound,
+    assign global_cfg_reg_2 = {6'd0, dgt_hscaling, config_spin_initial_skip_1, config_spin_initial_skip_0, multi_cmpt_mode_en, infinite_icon_loop_en, ctnus_dgt_debug, ctnus_fifo_read, dgt_addr_upper_bound,
                             debug_h_wwl, synchronizer_pipe_num,
                             dt_cfg_enable, config_valid_fm, config_valid_em,
                             config_valid_aw, cmpt_en};
@@ -489,16 +499,6 @@ function automatic lagd_reg_req_t gen_reg_req(
 endfunction
 
 task automatic reg_config();
-    integer i;
-    logic [`LAGD_REG_DATA_WIDTH-1:0] reg_data;
-
-    logic [`NUM_SPIN-1:0] config_spin_initial_0, config_spin_initial_1;
-    logic [`COUNTER_BITWIDTH-1:0] cycle_per_spin_write, cycle_per_wwl_low, cycle_per_wwl_high, cfg_trans_num;
-    logic [`SCALING_BIT-1:0] dgt_hscaling;
-    logic [$clog2(`FLIP_ICON_DEPTH):0] icon_last_raddr_plus_one;
-    logic [`COUNTER_BITWIDTH-1:0] debug_spin_read_num, debug_cycle_per_spin_read, cycle_per_spin_compute;
-    logic [`NUM_SPIN-1:0] wwl_vdd_cfg, wwl_vread_cfg, spin_wwl_strobe, spin_feedback, debug_j_one_hot_wwl;
-
     // Prepare configuration values
     flush_en = 1'b0;
     en_aw = 1'b1;
@@ -596,7 +596,7 @@ task automatic reg_config();
     @ (posedge clk_i);
     reg_ext_req = gen_reg_req(LAGD_CORE_COUNTER_CFG_3_OFFSET, 1'b1, reg_data, 1'b1);
     // Counters, set 4
-    reg_data = {dgt_hscaling, icon_last_raddr_plus_one, debug_spin_read_num};
+    reg_data = {5'd0, icon_last_raddr_plus_one, debug_spin_read_num};
     @ (posedge clk_i);
     reg_ext_req = gen_reg_req(LAGD_CORE_COUNTER_CFG_4_OFFSET, 1'b1, reg_data, 1'b1);
     // WWL VDD

--- a/hw/unit_tests/ising_core_wrap/tb_ising_core_wrap.sv
+++ b/hw/unit_tests/ising_core_wrap/tb_ising_core_wrap.sv
@@ -74,13 +74,16 @@ module tb_ising_core_wrap;
     logic [`IC_L1_J_MEM_ADDR_WIDTH-1:0] dgt_addr_upper_bound;
     logic ctnus_fifo_read, ctnus_dgt_debug, infinite_icon_loop_en, multi_cmpt_mode_en;
     logic [`LAGD_REG_DATA_WIDTH-1:0] global_cfg_reg_1, global_cfg_reg_2;
-    logic [(`NUM_SPIN*`BIT_J)-1:0] h_rdata, wbl_floating;
+    logic [(`NUM_SPIN*`BIT_H)-1:0] h_rdata, wbl_floating;
     logic [`CC_COUNTER_BITWIDTH-1:0] cmpt_max_num;
     logic axi_test_done;
     model_t model;
     logic [`CVA6_ADDR_WIDTH-1:0] axi_write_addr;
     logic [`LAGD_AXI_DATA_WIDTH-1:0] axi_write_data;
     logic [1024-1:0] [`NUM_SPIN-1:0] flip_icon;
+    logic [1:0] [`NUM_SPIN-1:0] spin_fifo_reg_data;
+    logic [1:0] [`ENERGY_TOTAL_BIT-1:0] energy_fifo_reg_data;
+    logic results_read_start;
 
     logic [`NUM_SPIN-1:0] config_spin_initial_0, config_spin_initial_1;
     logic [`COUNTER_BITWIDTH-1:0] cycle_per_spin_write, cycle_per_wwl_low, cycle_per_wwl_high, cfg_trans_num;
@@ -128,6 +131,38 @@ module tb_ising_core_wrap;
 
     assign reg_rsp_ready = reg_ext_rsp.ready;
     assign reg_rsp_rdata = reg_ext_rsp.rdata;
+
+    assign energy_fifo_reg_data[0] = dut.u_lagd_core_reg_top.energy_fifo_data_0_qs;
+    assign energy_fifo_reg_data[1] = dut.u_lagd_core_reg_top.energy_fifo_data_1_qs;
+    generate
+        for (genvar i = 0; i < `NUM_SPIN/`LAGD_REG_DATA_WIDTH; i=i+1) begin : spin_fifo_qs_gen_0
+            case(i)
+                0: assign spin_fifo_reg_data[0][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_0_0_qs;
+                1: assign spin_fifo_reg_data[0][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_0_1_qs;
+                2: assign spin_fifo_reg_data[0][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_0_2_qs;
+                3: assign spin_fifo_reg_data[0][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_0_3_qs;
+                4: assign spin_fifo_reg_data[0][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_0_4_qs;
+                5: assign spin_fifo_reg_data[0][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_0_5_qs;
+                6: assign spin_fifo_reg_data[0][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_0_6_qs;
+                7: assign spin_fifo_reg_data[0][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_0_7_qs;
+            endcase
+        end
+    endgenerate
+
+    generate
+        for (genvar i = 0; i < `NUM_SPIN/`LAGD_REG_DATA_WIDTH; i=i+1) begin : spin_fifo_qs_gen_1
+            case(i)
+                0: assign spin_fifo_reg_data[1][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_1_0_qs;
+                1: assign spin_fifo_reg_data[1][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_1_1_qs;
+                2: assign spin_fifo_reg_data[1][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_1_2_qs;
+                3: assign spin_fifo_reg_data[1][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_1_3_qs;
+                4: assign spin_fifo_reg_data[1][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_1_4_qs;
+                5: assign spin_fifo_reg_data[1][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_1_5_qs;
+                6: assign spin_fifo_reg_data[1][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_1_6_qs;
+                7: assign spin_fifo_reg_data[1][i*`LAGD_REG_DATA_WIDTH +: `LAGD_REG_DATA_WIDTH] = dut.u_lagd_core_reg_top.spin_fifo_data_1_7_qs;
+            endcase
+        end
+    endgenerate
 
     // Module instantiation
     ising_core_wrap #(
@@ -449,6 +484,7 @@ module tb_ising_core_wrap;
                     $error("Write failed with response: %0d", axi_ext_slv_rsp_0.b.resp);
             end
         end
+        @ (posedge clk_i);
         axi_ext_slv_req_0 = 'd0; // Deassert after use
 
         // axi1 test
@@ -465,6 +501,7 @@ module tb_ising_core_wrap;
             end
         end
         axi_ext_slv_req_1 = 'd0; // Deassert after use
+        @ (posedge clk_i);
         $display("AXI test completed successfully.");
         axi_test_done = 1'b1;
     end
@@ -481,6 +518,10 @@ module tb_ising_core_wrap;
         wait (axi_test_done == 1);
         // Initialize reg interfaces
         reg_config();
+        fork
+            results_read();
+            print_results_read();
+        join_none
     end
 
 function automatic lagd_reg_req_t gen_reg_req(
@@ -552,14 +593,14 @@ task automatic reg_config();
     icon_last_raddr_plus_one = `FLIP_ICON_DEPTH;
     debug_spin_read_num = `FLIP_ICON_DEPTH;
     debug_cycle_per_spin_read = 'd2;
-    cycle_per_spin_compute = 'd2;
+    cycle_per_spin_compute = 'd5;
 
     wwl_vdd_cfg     = {`NUM_SPIN{1'b1}}; // all high
     wwl_vread_cfg   = {`NUM_SPIN{1'b0}}; // all low
     spin_wwl_strobe = {`NUM_SPIN{1'b1}}; // all high
     spin_feedback   = {`NUM_SPIN{1'b1}}; // all high
 
-    h_rdata = {`NUM_SPIN{4'b1010}}; // alternating 1010
+    h_rdata = model.hbias;
     wbl_floating = {`NUM_SPIN{4'b0000}};
     debug_j_one_hot_wwl = 'd0;
 
@@ -676,6 +717,9 @@ task automatic reg_config();
     reg_ext_req = gen_reg_req(LAGD_CORE_OUTPUT_STATUS_OFFSET, 1'b0, 'd0, 1'b1);
     repeat (5) @ (posedge clk_i);
     wait (reg_ext_rsp.rdata[0] == 1'b1); // wait for dt configuration done
+    // Check initial spin value
+    $display("[Time: %t] Initial energy0 is: 'h%h, spin0 is: 'h%h", $time, dut.energy_fifo_data[0], dut.spin_fifo_data[0]);
+    $display("[Time: %t] Initial energy1 is: 'h%h, spin1 is: 'h%h", $time, dut.energy_fifo_data[1], dut.spin_fifo_data[1]);
     // Start computation
     en_ef = 1'b1;
     @ (posedge clk_i);
@@ -686,14 +730,73 @@ task automatic reg_config();
     cmpt_en = 1'b0;
     @ (posedge clk_i);
     reg_ext_req = gen_reg_req(LAGD_CORE_GLOBAL_CFG_2_OFFSET, 1'b1, global_cfg_reg_2, 1'b0);
+
     // switch to output register
     @ (posedge clk_i);
     reg_ext_req = gen_reg_req(LAGD_CORE_OUTPUT_STATUS_OFFSET, 1'b0, 'd0, 1'b1);
     repeat (2) @ (posedge clk_i);
-    wait (dut.debug_fm_downstream_handshake == 1'b1); // wait for the first handshake indicating the first output is ready
-    $display("Ending simulation.");
+    wait (reg_ext_rsp.rdata[1] == 1'b1); // wait for computation done
+    $display("------------------------------------------------");
     @ (posedge clk_i);
+    $display("[Time: %t] cmpt_idle: 'h%h, ctnus_fifo_read: 'h%h", $time, dut.cmpt_idle, dut.ctnus_fifo_read);
+    $display("[Time: %t] Final energy0 is: 'h%h, spin0 is: 'h%h", $time, energy_fifo_reg_data[0], spin_fifo_reg_data[0]);
+    $display("[Time: %t] Final energy1 is: 'h%h, spin1 is: 'h%h", $time, energy_fifo_reg_data[1], spin_fifo_reg_data[1]);
+    results_read_start = 1'b1;
+endtask
+
+task automatic results_read();
+    // read energy and spin values from output registers
+    wait (results_read_start == 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_ENERGY_FIFO_DATA_0_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_ENERGY_FIFO_DATA_1_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_0_0_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_0_1_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_0_2_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_0_3_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_0_4_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_0_5_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_0_6_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_0_7_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_1_0_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_1_1_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_1_2_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_1_3_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_1_4_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_1_5_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_1_6_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_1_7_OFFSET, 1'b0, 'd0, 1'b1);
+    @ (posedge clk_i);
+    reg_ext_req = gen_reg_req(LAGD_CORE_SPIN_FIFO_DATA_1_7_OFFSET, 1'b0, 'd0, 1'b0);
+    results_read_start = 1'b0;
     $finish;
+endtask
+
+task automatic print_results_read();
+    wait (results_read_start == 1'b1);
+    @ (posedge clk_i);
+    $display("--------- Print Results By Register Read ---------");
+    forever begin
+        @ (posedge clk_i);
+        $display("[Time: %t] reg_txt_rsp.rdata: 'h%h", $time, reg_ext_rsp.rdata);
+    end
 endtask
 
 endmodule


### PR DESCRIPTION
This PR is for increasing the supported hscaling factor from 5b to 6b, together with a few fixes on the tb and registers. It includes the following changes:

- Increase the hscaling factor from 5b to 6b.
- Adjust the CSR registers accordingly.
- Update the testbenches of digital macro, energy monitor, and Ising core wrap accordingly.
- The function of the digital macro and energy monitor has been re-verified.
- The basic function of ising_core_wrap has been verified using real data and the analog model (from the last PR).
- The performance counters' behavior in ising_core_wrap is fixed when infinite_icon_loop_en is 1.

No compilation error found in synthesis dry run.